### PR TITLE
fix: "div의 background 이미지 -> img 태그로 변경"

### DIFF
--- a/src/components/common/ThemeBadge.tsx
+++ b/src/components/common/ThemeBadge.tsx
@@ -5,8 +5,8 @@ interface IThemeBadge {
 export default function ({ text }: IThemeBadge) {
 
     return (
-        <div className='flex p-[8px] relative'>
-            <span className='absolute right-[6px] inline-flex items-center gap-x-sm py-[3px] px-[6px] rounded-full text-xs font-medium bg-gradient-to-r from-secondary to-primary text-white dark:bg-white dark:text-neutral-800'>{text}</span>
+        <div className='flex p-[8px] absolute right-[0px] top-[0px]'>
+            <span className='inline-flex items-center gap-x-sm py-[3px] px-[6px] rounded-full text-xs font-medium bg-gradient-to-r from-secondary to-primary text-white dark:bg-white dark:text-neutral-800'>{text}</span>
         </div>
     )
 }

--- a/src/components/common/ThemeCard.tsx
+++ b/src/components/common/ThemeCard.tsx
@@ -9,15 +9,13 @@ interface ThemeCardProps {
   content: string;
 }
 
-const CardContainer = styled.div<{ $image: string }>`
+const CardContainer = styled.img`
   width: 167px;
   height: 270px;
   border-radius: 8px;
-  position: relative;
   overflow: hidden;
-  background-image: linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4)), url(${(props) => props.$image});
-  background-size: cover;
-  background-position: center;
+  object-fit: cover;
+  filter: brightness(70%);
 `;
 
 const Content = styled.div`
@@ -35,10 +33,11 @@ export default function ThemeCard({ imageUrl = '/src/assets/images/a.jpg', theme
 
   return (
     <Link to={`create-card/${theme}`}>
-      <CardContainer $image={imageUrl}>
+      <div className='w-[167px] h-[270px] relative'>
+        <CardContainer src={imageUrl} />
         <ThemeBadge text={getThemeKR(theme)} />
         <Content>{content}</Content>
-      </CardContainer>
+      </div>
     </Link>
   );
 }

--- a/src/routes/Main.tsx
+++ b/src/routes/Main.tsx
@@ -7,27 +7,29 @@ import ThemeCard from '../components/common/ThemeCard';
 import { themeCardData } from '../stores/static';
 import PostCardsSection from '../components/posts/PostCardsSection';
 
-const BannerContainer = styled.div`
-  background-image: linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.3)), url('src/assets/images/banner.jpeg');
-  padding-top: 100px;
-  padding-left: 30px;
-  height: 300px;
-  background-size: cover;
-  background-position: center;
+const BannerContainer = styled.img`
+  object-fit: cover;
+  object-position: center;
+  height: 100%;
+  width: 100%;
+  filter: brightness(70%);
 `;
 
 export default function Main() {
   return (
-    <div>
-      <BannerContainer>
-        <h2 className='text-[30px] font-bold text-white'>
-          굳이? 굳이! <br /> 특별한 하루를 위한 <span className='text-primary'>굳이데이</span>
-        </h2>
-        <div className='text-white py-[20px]'>
-          <p className='py-[10px]'>🎲 다양한 옵션 설정으로 나만의 랜덤 굳이데이 카드를 만들어요</p>
-          <p>👫 내가 실천한 굳이데이를 다른 사람들과 공유해요</p>
+    <div >
+      <div className='w-full h-[300px] overflow-hidden relative'>
+        <BannerContainer src='src/assets/images/banner.jpeg' />
+        <div className='pt-[80px] pl-[20px] absolute top-[0px]'>
+          <h2 className='text-[30px] font-bold text-white'>
+            굳이? 굳이! <br /> 특별한 하루를 위한 <span className='text-primary'>굳이데이</span>
+          </h2>111
+          <div className='text-white py-[20px] '>
+            <p className='py-[10px]'>🎲 다양한 옵션 설정으로 나만의 랜덤 굳이데이 카드를 만들어요</p>
+            <p>👫 내가 실천한 굳이데이를 다른 사람들과 공유해요</p>
+          </div>
         </div>
-      </BannerContainer>
+      </div>
       <MainTitle text='굳이 ? 굳이! 굳이데이로 재밌는 추억 만들기 ✌🏻' />
       <SubTitle text='테마가 설정된 카드를 사용하면 더 쉽게 굳이데이 카드를 생성할 수 있어요!' />
       <ThemeCardsGrid>


### PR DESCRIPTION
## 내용
페이지 이동과 새로고침 시, styled-component의 style로 만들었던 div 태그 내부에 props 값으로 넘겼던 이미지의 url을 불러오지 못하는 현상을 수정하였습니다.


## PR 유형
어떤 변경 사항이 있나요? (중괄호 내부에 x를 추가하세요)

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
